### PR TITLE
clarification on scope of purpose for this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # SST Documentation
-Documentation for SST
+Documentation for the Structural Simulation Toolkit (SST). 
+
+This repo is intended for documentation that is to go on the website <https://sst-simulator.org/>. (For tutorials that are intended as self-paced walkthroughs, see <https://github.com/sstsimulator/sst-tutorials>. )
 
 Contributions to this repository should be submitted as pull requests.
 
 Documentation should be in LaTeX format and use the macros/definitions provided
-in the sstmanual.sty file. This template supports conversion between LaTeX and 
+in the `sstmanual.sty` file. This template supports conversion between LaTeX and 
 Markdown formats.
 


### PR DESCRIPTION
- expanded abbreviation for SST. 
- provided a link to `sst-tutorials` repo since new users to SST might look to this repo first when seeking guidance on how to use SST.